### PR TITLE
add experiment no.2

### DIFF
--- a/app/experiments.py
+++ b/app/experiments.py
@@ -11,9 +11,23 @@ logger = logging.getLogger(__name__)
 
 @profile
 def exec_experiment_1(db: str):
-    logger.info("Execute the experiment#1 with db(%s)", db)
+    logger.info("Execute the experiment#1 with db = %s", db)
 
     engine = create_db_engine(db)
     dataframe = pd.read_sql("SELECT * FROM users", engine)
 
     logger.info("Got %s records", len(dataframe))
+
+
+@profile
+def exec_experiment_2(db: str, chunksize: int):
+    logger.info("Execute the experiment#1 with db = %s, chunksize = %s", db, chunksize)
+    total = 0
+    chunksize = int(chunksize)
+
+    engine = create_db_engine(db)
+    it = pd.read_sql("SELECT * FROM users", engine, chunksize=chunksize)
+    for chunk in it:
+        total += len(chunk)
+
+    logger.info("Got %s records", total)

--- a/app/initialize.py
+++ b/app/initialize.py
@@ -64,7 +64,7 @@ def initialize_postgres(nrows: int) -> int:
 
     engine = create_postgres_engine()
 
-    logger.info("Start adding rows")
+    logger.info("Start adding %s rows", nrows)
     added_rows = initialize_table(engine, nrows)
     logger.info("Added rows count = %s", added_rows)
 

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -5,7 +5,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 
 from db import create_mysql_engine, create_postgres_engine, create_db_engine
 from initialize import initialize_mysql, initialize_postgres
-from experiments import exec_experiment_1
+from experiments import *
 
 
 logging.basicConfig(format='[%(levelname)s] %(funcName)s: %(message)s', level=logging.INFO)
@@ -35,6 +35,11 @@ def init(c, nrows):
 @task
 def exp1(c, db):
     exec_experiment_1(db)
+
+
+@task
+def exp2(c, db, chunksize):
+    exec_experiment_2(db, chunksize)
 
 
 if __name__ == '__main__':

--- a/run.sh
+++ b/run.sh
@@ -2,24 +2,33 @@
 
 APP="docker compose run --rm app"
 
-if [ $# -ne 1 ]; then
-	echo "Specify the number of rows"
+if [ $# -ne 2 ]; then
+	echo "Specify the number of rows and the chunksize"
 	exit 2
 fi
 
 NROWS=$1
+CHUNKSIZE=$2
 
 function die () {
 	docker compose down
 	exit 1
 }
 
+function do_exps () {
+	DB=$1
+	$APP exp1 --db $DB || die
+	$APP exp2 --db $DB --chunksize $CHUNKSIZE || die
+}
+
 docker compose build
 docker compose up -d mysql postgres
 
 $APP init --nrows $NROWS || die
-$APP exp1 --db mysql || die
-$APP exp1 --db postgres || die
+
+do_exps "mysql"
+do_exps "postgres"
+
 
 docker compose down
 


### PR DESCRIPTION
- fix: `exp1` takes a database name instead of an engine
- fix: docker compose starts only database services
- feat: add a task exp2
